### PR TITLE
[ci skip] removing user @goanpeca

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -44,6 +44,5 @@ about:
 
 extra:
   recipe-maintainers:
-    - goanpeca
     - jaimergp
     - sameeul


### PR DESCRIPTION
Manually removing @goanpeca from the maintainers list because the conda-forge-admin bot has not processed the request.

Closes #3